### PR TITLE
Loosen bounds for ansi-terminal and which

### DIFF
--- a/cli-extras.cabal
+++ b/cli-extras.cabal
@@ -40,7 +40,7 @@ library
   ghc-options:      -Wall -fobject-code
   build-depends:
       aeson           >=1.4.4.0  && <1.5
-    , ansi-terminal   >=0.9.1    && <0.10
+    , ansi-terminal   >=0.9.1    && <0.12
     , base            >=4.12.0.0 && <4.15
     , bytestring      >=0.10.8.2 && <0.11
     , containers      >=0.6.0.1  && <0.7
@@ -56,7 +56,7 @@ library
     , text            >=1.2.3.1  && <1.3
     , time            >=1.8.0.2  && <1.12
     , transformers    >=0.5.6.2  && <0.6
-    , which           >=0.2      && <0.3
+    , which           >=0.1      && <0.3
 
 source-repository head
   type:     git


### PR DESCRIPTION
With these changes, this package can build with the package set in NixOS 20.09, with the only override being `unliftio-core_0_2_0_1`, which is needed for `logging-effect`.