### PR TITLE
Bump bounds to allow GHC 9.0

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ['8.6.5', '8.8.4', '8.10.7', '9.0.1']
+        ghc: ['8.6.5', '8.8.4', '8.10.7', '9.0.1', '9.2.2']
         os: ['ubuntu-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -6,14 +6,14 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ['8.6.5', '8.8.4']
+        ghc: ['8.6.5', '8.8.4', '8.10.7', '9.0.1']
         os: ['ubuntu-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
 
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v1
       with:
         ghc-version: ${{ matrix.ghc }}
     - name: Cache

--- a/cli-extras.cabal
+++ b/cli-extras.cabal
@@ -19,7 +19,7 @@ build-type:         Simple
 extra-source-files: CHANGELOG.md
                     README.md
 
-tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.1
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.1 || ==9.2.2
 
 library
   exposed-modules:
@@ -41,12 +41,12 @@ library
   build-depends:
       aeson           >=1.4.4.0  && <2.1
     , ansi-terminal   >=0.9.1    && <0.12
-    , base            >=4.12.0.0 && <4.16
-    , bytestring      >=0.10.8.2 && <0.11
+    , base            >=4.12.0.0 && <4.17
+    , bytestring      >=0.10.8.2 && <0.12
     , containers      >=0.6.0.1  && <0.7
     , exceptions      >=0.10.3   && <0.11
     , io-streams      >=1.5.1.0  && <1.6
-    , lens            >=4.17.1   && <5.1
+    , lens            >=4.17.1   && <5.2
     , logging-effect  >=1.3.4    && <1.4
     , monad-logger    >=0.3.30   && <0.4
     , monad-loops     >=0.4.3    && <0.5

--- a/cli-extras.cabal
+++ b/cli-extras.cabal
@@ -19,7 +19,7 @@ build-type:         Simple
 extra-source-files: CHANGELOG.md
                     README.md
 
-tested-with: GHC ==8.6.5 || ==8.8.4
+tested-with: GHC ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.1
 
 library
   exposed-modules:
@@ -39,14 +39,14 @@ library
   default-language: Haskell2010
   ghc-options:      -Wall -fobject-code
   build-depends:
-      aeson           >=1.4.4.0  && <1.6
+      aeson           >=1.4.4.0  && <2.1
     , ansi-terminal   >=0.9.1    && <0.12
-    , base            >=4.12.0.0 && <4.15
+    , base            >=4.12.0.0 && <4.16
     , bytestring      >=0.10.8.2 && <0.11
     , containers      >=0.6.0.1  && <0.7
     , exceptions      >=0.10.3   && <0.11
     , io-streams      >=1.5.1.0  && <1.6
-    , lens            >=4.17.1   && <4.20
+    , lens            >=4.17.1   && <5.1
     , logging-effect  >=1.3.4    && <1.4
     , monad-logger    >=0.3.30   && <0.4
     , monad-loops     >=0.4.3    && <0.5


### PR DESCRIPTION
This allows building with the NixOS 22.05 package set.